### PR TITLE
Re-ran the nim doc generator after fixing repository typo bug

### DIFF
--- a/docs/nim-cmds/action.md
+++ b/docs/nim-cmds/action.md
@@ -3,20 +3,20 @@
 
 work with actions
 
-* [`nim action create [ACTIONNAME] ACTIONPATH`](#nim-action-create-actionname-actionpath)
+* [`nim action create ACTIONNAME [ACTIONPATH]`](#nim-action-create-actionname-actionpath)
 * [`nim action delete ACTIONNAME`](#nim-action-delete-actionname)
 * [`nim action get ACTIONNAME`](#nim-action-get-actionname)
 * [`nim action invoke ACTIONNAME`](#nim-action-invoke-actionname)
 * [`nim action list [PACKAGENAME]`](#nim-action-list-packagename)
 * [`nim action update ACTIONNAME [ACTIONPATH]`](#nim-action-update-actionname-actionpath)
 
-## `nim action create [ACTIONNAME] ACTIONPATH`
+## `nim action create ACTIONNAME [ACTIONPATH]`
 
 Creates an Action
 
 ```
 USAGE
-  $ nim action create [ACTIONNAME] ACTIONPATH
+  $ nim action create ACTIONNAME [ACTIONPATH]
 
 OPTIONS
   -A, --annotation-file=annotation-file  FILE containing annotation values in JSON format
@@ -49,8 +49,6 @@ OPTIONS
   --web-secure=web-secure                secure the web action (valid values are true, false, or any string)
 ```
 
-_See code: [src/commands/action/create.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/create.ts)_
-
 This command provides a quick way to create an individual action, not connected to a project.  However, [a project with a single action in it](single-action-example.md), while bulkier, allows for future extension as you add more actions and web content to your application.
 
 The action being created must not already exist.  If you wish to modify an existing action, use [nim action update](#nim-package-update-packagename).
@@ -71,6 +69,8 @@ Although it is the first argument, the `ACTIONNAME` may be omitted, causing the 
 #### ACTIONPATH
 
 Provides a location in the local file system where the code of the action is to be found.  
+
+_See code: [src/commands/action/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/create.ts)_
 
 ## `nim action delete ACTIONNAME`
 
@@ -94,8 +94,6 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/action/delete.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/delete.ts)_
-
 This command deletes a single action.  You can also delete all the actions in a package along with the package itself using
 
 ```
@@ -107,6 +105,8 @@ You can delete all the OpenWhisk resources in a namespace using
 ```
 nim namespace clean --justwhisk
 ```
+
+_See code: [src/commands/action/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/delete.ts)_
 
 ## `nim action get ACTIONNAME`
 
@@ -133,7 +133,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/action/get.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/get.ts)_
+_See code: [src/commands/action/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/get.ts)_
 
 ## `nim action invoke ACTIONNAME`
 
@@ -158,9 +158,10 @@ OPTIONS
   --help                       Show help
   --key=key                    client key
   --version                    Show version
+  --web                        Invoke as a web action, show result as web page
 ```
 
-_See code: [src/commands/action/invoke.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/invoke.ts)_
+_See code: [src/commands/action/invoke.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/invoke.ts)_
 
 ## `nim action list [PACKAGENAME]`
 
@@ -189,7 +190,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/action/list.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/list.ts)_
+_See code: [src/commands/action/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/list.ts)_
 
 ## `nim action update ACTIONNAME [ACTIONPATH]`
 
@@ -230,4 +231,4 @@ OPTIONS
   --web-secure=web-secure                secure the web action (valid values are true, false, or any string)
 ```
 
-_See code: [src/commands/action/update.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/update.ts)_
+_See code: [src/commands/action/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/action/update.ts)_

--- a/docs/nim-cmds/activation.md
+++ b/docs/nim-cmds/activation.md
@@ -35,7 +35,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/activation/get.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/activation/get.ts)_
+_See code: [src/commands/activation/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/activation/get.ts)_
 
 ## `nim activation list [ACTIVATION_NAME]`
 
@@ -65,7 +65,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/activation/list.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/activation/list.ts)_
+_See code: [src/commands/activation/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/activation/list.ts)_
 
 ## `nim activation logs [ACTIVATIONID]`
 
@@ -95,7 +95,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/activation/logs.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/activation/logs.ts)_
+_See code: [src/commands/activation/logs.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/activation/logs.ts)_
 
 ## `nim activation result [ACTIVATIONID]`
 
@@ -121,4 +121,4 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/activation/result.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/activation/result.ts)_
+_See code: [src/commands/activation/result.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/activation/result.ts)_

--- a/docs/nim-cmds/auth.md
+++ b/docs/nim-cmds/auth.md
@@ -34,7 +34,7 @@ OPTIONS
   --web          Show web domain (if available)
 ```
 
-_See code: [src/commands/auth/current.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/current.ts)_
+_See code: [src/commands/auth/current.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/current.ts)_
 
 ## `nim auth export [NAMESPACE]`
 
@@ -55,7 +55,7 @@ OPTIONS
   --non-expiring     Generate non-expiring token (for functional ids and integrations)
 ```
 
-_See code: [src/commands/auth/export.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/export.ts)_
+_See code: [src/commands/auth/export.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/export.ts)_
 
 ## `nim auth github`
 
@@ -78,7 +78,7 @@ OPTIONS
   --username=username  The GitHub username when adding an account manually
 ```
 
-_See code: [src/commands/auth/github.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/github.ts)_
+_See code: [src/commands/auth/github.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/github.ts)_
 
 ## `nim auth list`
 
@@ -93,7 +93,7 @@ OPTIONS
   --help         Show help
 ```
 
-_See code: [src/commands/auth/list.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/list.ts)_
+_See code: [src/commands/auth/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/list.ts)_
 
 ## `nim auth login [TOKEN]`
 
@@ -116,7 +116,7 @@ ALIASES
   $ nim login
 ```
 
-_See code: [src/commands/auth/login.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/login.ts)_
+_See code: [src/commands/auth/login.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/login.ts)_
 
 ## `nim auth logout [NAMESPACE]`
 
@@ -139,7 +139,7 @@ ALIASES
   $ nim logout
 ```
 
-_See code: [src/commands/auth/logout.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/logout.ts)_
+_See code: [src/commands/auth/logout.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/logout.ts)_
 
 ## `nim auth refresh [NAMESPACE]`
 
@@ -158,7 +158,7 @@ OPTIONS
   --help             Show help
 ```
 
-_See code: [src/commands/auth/refresh.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/refresh.ts)_
+_See code: [src/commands/auth/refresh.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/refresh.ts)_
 
 ## `nim auth switch NAMESPACE`
 
@@ -177,4 +177,4 @@ OPTIONS
   --help             Show help
 ```
 
-_See code: [src/commands/auth/switch.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/switch.ts)_
+_See code: [src/commands/auth/switch.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/auth/switch.ts)_

--- a/docs/nim-cmds/doc.md
+++ b/docs/nim-cmds/doc.md
@@ -21,4 +21,4 @@ ALIASES
   $ nim docs
 ```
 
-_See code: [src/commands/doc.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/doc.ts)_
+_See code: [src/commands/doc.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/doc.ts)_

--- a/docs/nim-cmds/info.md
+++ b/docs/nim-cmds/info.md
@@ -22,4 +22,4 @@ OPTIONS
   --runtimes     List the supported runtimes
 ```
 
-_See code: [src/commands/info.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/info.ts)_
+_See code: [src/commands/info.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/info.ts)_

--- a/docs/nim-cmds/key-value.md
+++ b/docs/nim-cmds/key-value.md
@@ -34,7 +34,7 @@ ALIASES
   $ nim kv clean
 ```
 
-_See code: [src/commands/key-value/clean.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/clean.ts)_
+_See code: [src/commands/key-value/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/clean.ts)_
 
 ## `nim key-value del KEY`
 
@@ -57,7 +57,7 @@ ALIASES
   $ nim kv delete
 ```
 
-_See code: [src/commands/key-value/del.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/del.ts)_
+_See code: [src/commands/key-value/del.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/del.ts)_
 
 ## `nim key-value expire KEY TTL`
 
@@ -80,7 +80,7 @@ ALIASES
   $ nim kv expire
 ```
 
-_See code: [src/commands/key-value/expire.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/expire.ts)_
+_See code: [src/commands/key-value/expire.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/expire.ts)_
 
 ## `nim key-value get KEY`
 
@@ -102,7 +102,7 @@ ALIASES
   $ nim kv get
 ```
 
-_See code: [src/commands/key-value/get.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/get.ts)_
+_See code: [src/commands/key-value/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/get.ts)_
 
 ## `nim key-value getMany [KEYPREFIX] [STARTINDEX] [COUNT]`
 
@@ -127,7 +127,7 @@ ALIASES
   $ nim kv getmany
 ```
 
-_See code: [src/commands/key-value/getMany.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/getMany.ts)_
+_See code: [src/commands/key-value/getMany.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/getMany.ts)_
 
 ## `nim key-value list [PREFIX]`
 
@@ -150,7 +150,7 @@ ALIASES
   $ nim kv list
 ```
 
-_See code: [src/commands/key-value/list.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/list.ts)_
+_See code: [src/commands/key-value/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/list.ts)_
 
 ## `nim key-value llen KEY`
 
@@ -172,7 +172,7 @@ ALIASES
   $ nim kv llen
 ```
 
-_See code: [src/commands/key-value/llen.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/llen.ts)_
+_See code: [src/commands/key-value/llen.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/llen.ts)_
 
 ## `nim key-value lrange KEY START STOP`
 
@@ -196,7 +196,7 @@ ALIASES
   $ nim kv lrange
 ```
 
-_See code: [src/commands/key-value/lrange.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/lrange.ts)_
+_See code: [src/commands/key-value/lrange.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/lrange.ts)_
 
 ## `nim key-value rpush KEY VALUE`
 
@@ -219,7 +219,7 @@ ALIASES
   $ nim kv rpush
 ```
 
-_See code: [src/commands/key-value/rpush.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/rpush.ts)_
+_See code: [src/commands/key-value/rpush.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/rpush.ts)_
 
 ## `nim key-value set KEY VALUE`
 
@@ -243,7 +243,7 @@ ALIASES
   $ nim kv add
 ```
 
-_See code: [src/commands/key-value/set.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/set.ts)_
+_See code: [src/commands/key-value/set.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/set.ts)_
 
 ## `nim key-value setMany [KEYPREFIX] [VALUEPREFIX] [STARTINDEX] [COUNT]`
 
@@ -269,7 +269,7 @@ ALIASES
   $ nim kv setmany
 ```
 
-_See code: [src/commands/key-value/setMany.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/setMany.ts)_
+_See code: [src/commands/key-value/setMany.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/setMany.ts)_
 
 ## `nim key-value ttl KEY`
 
@@ -291,4 +291,4 @@ ALIASES
   $ nim kv ttl
 ```
 
-_See code: [src/commands/key-value/ttl.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/ttl.ts)_
+_See code: [src/commands/key-value/ttl.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/key-value/ttl.ts)_

--- a/docs/nim-cmds/namespace.md
+++ b/docs/nim-cmds/namespace.md
@@ -27,7 +27,7 @@ OPTIONS
   --justwhisk        Remove only OpenWhisk entities, leaving other content
 ```
 
-_See code: [src/commands/namespace/clean.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/namespace/clean.ts)_
+_See code: [src/commands/namespace/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/namespace/clean.ts)_
 
 ## `nim namespace free [NAMESPACE]`
 
@@ -47,7 +47,7 @@ OPTIONS
   --help             Show help
 ```
 
-_See code: [src/commands/namespace/free.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/namespace/free.ts)_
+_See code: [src/commands/namespace/free.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/namespace/free.ts)_
 
 ## `nim namespace get`
 
@@ -73,4 +73,4 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/namespace/get.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/namespace/get.ts)_
+_See code: [src/commands/namespace/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/namespace/get.ts)_

--- a/docs/nim-cmds/object.md
+++ b/docs/nim-cmds/object.md
@@ -29,7 +29,7 @@ OPTIONS
   --help             Show help
 ```
 
-_See code: [src/commands/object/clean.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/clean.ts)_
+_See code: [src/commands/object/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/clean.ts)_
 
 ## `nim object create OBJECTPATH [NAMESPACE]`
 
@@ -54,7 +54,7 @@ ALIASES
   $ nim object add
 ```
 
-_See code: [src/commands/object/create.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/create.ts)_
+_See code: [src/commands/object/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/create.ts)_
 
 ## `nim object delete OBJECTNAME [NAMESPACE]`
 
@@ -74,7 +74,7 @@ OPTIONS
   --help             Show help
 ```
 
-_See code: [src/commands/object/delete.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/delete.ts)_
+_See code: [src/commands/object/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/delete.ts)_
 
 ## `nim object get OBJECTNAME DESTINATION [NAMESPACE]`
 
@@ -97,7 +97,7 @@ OPTIONS
   --saveAs=saveAs    Saves object on file system with the given name
 ```
 
-_See code: [src/commands/object/get.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/get.ts)_
+_See code: [src/commands/object/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/get.ts)_
 
 ## `nim object list [PREFIX]`
 
@@ -118,7 +118,7 @@ OPTIONS
   --namespace=namespace  The namespace to list objects from (current namespace if omitted)
 ```
 
-_See code: [src/commands/object/list.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/list.ts)_
+_See code: [src/commands/object/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/list.ts)_
 
 ## `nim object update OBJECTPATH [NAMESPACE]`
 
@@ -139,7 +139,7 @@ OPTIONS
   --help                         Show help
 ```
 
-_See code: [src/commands/object/update.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/update.ts)_
+_See code: [src/commands/object/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/update.ts)_
 
 ## `nim object url OBJECTNAME [NAMESPACE]`
 
@@ -161,4 +161,4 @@ OPTIONS
   --help                       Show help
 ```
 
-_See code: [src/commands/object/url.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/url.ts)_
+_See code: [src/commands/object/url.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/object/url.ts)_

--- a/docs/nim-cmds/package.md
+++ b/docs/nim-cmds/package.md
@@ -36,7 +36,7 @@ OPTIONS
   --version                              Show version
 ```
 
-_See code: [src/commands/package/bind.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/bind.ts)_
+_See code: [src/commands/package/bind.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/bind.ts)_
 
 ## `nim package create PACKAGENAME`
 
@@ -65,7 +65,7 @@ OPTIONS
   --version                              Show version
 ```
 
-_See code: [src/commands/package/create.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/create.ts)_
+_See code: [src/commands/package/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/create.ts)_
 
 ## `nim package delete PACKAGENAME`
 
@@ -82,7 +82,7 @@ OPTIONS
   --json             output raw json
 ```
 
-_See code: [src/commands/package/delete.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/delete.ts)_
+_See code: [src/commands/package/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/delete.ts)_
 
 ## `nim package get PACKAGENAME`
 
@@ -105,7 +105,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/package/get.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/get.ts)_
+_See code: [src/commands/package/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/get.ts)_
 
 ## `nim package list [NAMESPACE]`
 
@@ -134,7 +134,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/package/list.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/list.ts)_
+_See code: [src/commands/package/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/list.ts)_
 
 ## `nim package update PACKAGENAME`
 
@@ -163,4 +163,4 @@ OPTIONS
   --version                              Show version
 ```
 
-_See code: [src/commands/package/update.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/update.ts)_
+_See code: [src/commands/package/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/package/update.ts)_

--- a/docs/nim-cmds/project.md
+++ b/docs/nim-cmds/project.md
@@ -31,7 +31,7 @@ OPTIONS
   --help                                     Show help
 ```
 
-_See code: [src/commands/project/create.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/project/create.ts)_
+_See code: [src/commands/project/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/project/create.ts)_
 
 ## `nim project deploy [PROJECTS]`
 
@@ -63,7 +63,7 @@ OPTIONS
   --yarn                 Use yarn instead of npm for node builds
 ```
 
-_See code: [src/commands/project/deploy.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/project/deploy.ts)_
+_See code: [src/commands/project/deploy.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/project/deploy.ts)_
 
 ## `nim project watch [PROJECTS]`
 
@@ -92,4 +92,4 @@ OPTIONS
   --yarn                 Use yarn instead of npm for node builds
 ```
 
-_See code: [src/commands/project/watch.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/project/watch.ts)_
+_See code: [src/commands/project/watch.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/project/watch.ts)_

--- a/docs/nim-cmds/route.md
+++ b/docs/nim-cmds/route.md
@@ -37,7 +37,7 @@ OPTIONS
   --version                                         Show version
 ```
 
-_See code: [src/commands/route/create.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/route/create.ts)_
+_See code: [src/commands/route/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/route/create.ts)_
 
 ## `nim route delete BASEPATHORAPINAME [RELPATH] [APIVERB]`
 
@@ -65,7 +65,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/route/delete.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/route/delete.ts)_
+_See code: [src/commands/route/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/route/delete.ts)_
 
 ## `nim route get BASEPATHORAPINAME`
 
@@ -91,7 +91,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/route/get.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/route/get.ts)_
+_See code: [src/commands/route/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/route/get.ts)_
 
 ## `nim route list [BASEPATH] [RELPATH] [APIVERB]`
 
@@ -122,4 +122,4 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/route/list.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/route/list.ts)_
+_See code: [src/commands/route/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/route/list.ts)_

--- a/docs/nim-cmds/rule.md
+++ b/docs/nim-cmds/rule.md
@@ -39,7 +39,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/create.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/create.ts)_
+_See code: [src/commands/rule/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/create.ts)_
 
 ## `nim rule delete NAME`
 
@@ -66,7 +66,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/delete.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/delete.ts)_
+_See code: [src/commands/rule/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/delete.ts)_
 
 ## `nim rule disable NAME`
 
@@ -92,7 +92,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/disable.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/disable.ts)_
+_See code: [src/commands/rule/disable.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/disable.ts)_
 
 ## `nim rule enable NAME`
 
@@ -118,7 +118,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/enable.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/enable.ts)_
+_See code: [src/commands/rule/enable.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/enable.ts)_
 
 ## `nim rule get NAME`
 
@@ -144,7 +144,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/get.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/get.ts)_
+_See code: [src/commands/rule/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/get.ts)_
 
 ## `nim rule list`
 
@@ -173,7 +173,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/list.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/list.ts)_
+_See code: [src/commands/rule/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/list.ts)_
 
 ## `nim rule status NAME`
 
@@ -199,7 +199,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/status.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/status.ts)_
+_See code: [src/commands/rule/status.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/status.ts)_
 
 ## `nim rule update NAME TRIGGER ACTION`
 
@@ -228,4 +228,4 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/update.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/update.ts)_
+_See code: [src/commands/rule/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/rule/update.ts)_

--- a/docs/nim-cmds/trigger.md
+++ b/docs/nim-cmds/trigger.md
@@ -39,7 +39,7 @@ OPTIONS
   --version                              Show version
 ```
 
-_See code: [src/commands/trigger/create.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/create.ts)_
+_See code: [src/commands/trigger/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/create.ts)_
 
 ## `nim trigger delete TRIGGERPATH`
 
@@ -65,7 +65,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/trigger/delete.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/delete.ts)_
+_See code: [src/commands/trigger/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/delete.ts)_
 
 ## `nim trigger fire TRIGGERNAME`
 
@@ -93,7 +93,7 @@ OPTIONS
   --version                    Show version
 ```
 
-_See code: [src/commands/trigger/fire.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/fire.ts)_
+_See code: [src/commands/trigger/fire.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/fire.ts)_
 
 ## `nim trigger get TRIGGERPATH`
 
@@ -119,7 +119,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/trigger/get.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/get.ts)_
+_See code: [src/commands/trigger/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/get.ts)_
 
 ## `nim trigger list`
 
@@ -148,7 +148,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/trigger/list.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/list.ts)_
+_See code: [src/commands/trigger/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/list.ts)_
 
 ## `nim trigger update TRIGGERNAME`
 
@@ -178,4 +178,4 @@ OPTIONS
   --version                              Show version
 ```
 
-_See code: [src/commands/trigger/update.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/update.ts)_
+_See code: [src/commands/trigger/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/trigger/update.ts)_

--- a/docs/nim-cmds/web.md
+++ b/docs/nim-cmds/web.md
@@ -28,7 +28,7 @@ OPTIONS
   --help             Show help
 ```
 
-_See code: [src/commands/web/clean.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/clean.ts)_
+_See code: [src/commands/web/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/clean.ts)_
 
 ## `nim web create WEBCONTENTPATH [NAMESPACE]`
 
@@ -53,7 +53,7 @@ ALIASES
   $ nim web add
 ```
 
-_See code: [src/commands/web/create.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/create.ts)_
+_See code: [src/commands/web/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/create.ts)_
 
 ## `nim web delete WEBCONTENTNAME [NAMESPACE]`
 
@@ -73,7 +73,7 @@ OPTIONS
   --help             Show help
 ```
 
-_See code: [src/commands/web/delete.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/delete.ts)_
+_See code: [src/commands/web/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/delete.ts)_
 
 ## `nim web get WEBCONTENTNAME DESTINATION [NAMESPACE]`
 
@@ -97,7 +97,7 @@ OPTIONS
   --saveAs=saveAs    Saves content on file system with the given name
 ```
 
-_See code: [src/commands/web/get.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/get.ts)_
+_See code: [src/commands/web/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/get.ts)_
 
 ## `nim web list [PREFIX]`
 
@@ -118,7 +118,7 @@ OPTIONS
   --namespace=namespace  The namespace to list web content from (current namespace if omitted)
 ```
 
-_See code: [src/commands/web/list.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/list.ts)_
+_See code: [src/commands/web/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/list.ts)_
 
 ## `nim web update WEBCONTENTPATH [NAMESPACE]`
 
@@ -140,4 +140,4 @@ OPTIONS
   --help                         Show help
 ```
 
-_See code: [src/commands/web/update.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/update.ts)_
+_See code: [src/commands/web/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/web/update.ts)_

--- a/docs/nim-cmds/workbench.md
+++ b/docs/nim-cmds/workbench.md
@@ -23,7 +23,7 @@ ALIASES
   $ nim wb login
 ```
 
-_See code: [src/commands/workbench/login.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/workbench/login.ts)_
+_See code: [src/commands/workbench/login.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/workbench/login.ts)_
 
 ## `nim workbench run [COMMAND]`
 
@@ -45,4 +45,4 @@ ALIASES
   $ nim wb run
 ```
 
-_See code: [src/commands/workbench/run.ts](https://github.com//nimbella/nimbella-cli/blob/v1.9.3/src/commands/workbench/run.ts)_
+_See code: [src/commands/workbench/run.ts](https://github.com/nimbella/nimbella-cli/blob/v1.9.3/src/commands/workbench/run.ts)_


### PR DESCRIPTION
This PR mostly just fixes double slashes in code references.   I fixed a bug in the code repo (the `package.json` file actually had the bad syntax in its `repository` member).   I then regenerated the files and re-did my additions in the one I had already modified.