### PR TITLE
Update automatically generated docs for 1.14

### DIFF
--- a/docs/command-summary.md
+++ b/docs/command-summary.md
@@ -6,7 +6,7 @@ sidebar_label: Nim Command Summary
 
 ## Nimbella CLI Command Summary
 
-The documents here cover the top level commands and topics of the Nimbella CLI.  Each document covers the syntax of its commands in the style of the command help but with more extended explanations.  Flags common to many commands are documented in [common-flags.md](common-flags.md) to avoid repetition.
+The documents here cover the top level commands and topics of the Nimbella CLI.  Each document covers the syntax of its commands in the style of the command help.  Flags common to many commands are documented in [common-flags.md](common-flags.md).
 
 ### TOPICS
 - [action](nim-cmds/action.md)  **work with actions**

--- a/docs/nim-cmds/action.md
+++ b/docs/nim-cmds/action.md
@@ -51,7 +51,7 @@ OPTIONS
   --web-secure=web-secure                secure the web action (valid values are true, false, or any string)
 ```
 
-_See code: [src/commands/action/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/action/create.ts)_
+_See code: [src/commands/action/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/action/create.ts)_
 
 ## `nim action delete ACTIONNAME`
 
@@ -64,6 +64,7 @@ USAGE
   $ nim action delete ACTIONNAME
 
 OPTIONS
+  -f, --force              Just do it, omitting confirmatory prompt
   -i, --insecure           bypass certificate check
   -u, --auth=auth          whisk auth
   -v, --verbose            Verbose output
@@ -77,7 +78,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/action/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/action/delete.ts)_
+_See code: [src/commands/action/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/action/delete.ts)_
 
 ## `nim action get ACTIONNAME`
 
@@ -108,7 +109,7 @@ OPTIONS
   --version                          Show version
 ```
 
-_See code: [src/commands/action/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/action/get.ts)_
+_See code: [src/commands/action/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/action/get.ts)_
 
 ## `nim action invoke ACTIONNAME`
 
@@ -138,7 +139,7 @@ OPTIONS
   --web                        Invoke as a web action, show result as web page
 ```
 
-_See code: [src/commands/action/invoke.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/action/invoke.ts)_
+_See code: [src/commands/action/invoke.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/action/invoke.ts)_
 
 ## `nim action list [PACKAGENAME]`
 
@@ -169,7 +170,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/action/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/action/list.ts)_
+_See code: [src/commands/action/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/action/list.ts)_
 
 ## `nim action update ACTIONNAME [ACTIONPATH]`
 
@@ -212,4 +213,4 @@ OPTIONS
   --web-secure=web-secure                secure the web action (valid values are true, false, or any string)
 ```
 
-_See code: [src/commands/action/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/action/update.ts)_
+_See code: [src/commands/action/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/action/update.ts)_

--- a/docs/nim-cmds/activation.md
+++ b/docs/nim-cmds/activation.md
@@ -37,7 +37,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/activation/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/activation/get.ts)_
+_See code: [src/commands/activation/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/activation/get.ts)_
 
 ## `nim activation list [ACTIVATION_NAME]`
 
@@ -69,7 +69,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/activation/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/activation/list.ts)_
+_See code: [src/commands/activation/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/activation/list.ts)_
 
 ## `nim activation logs [ACTIVATIONID]`
 
@@ -104,7 +104,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/activation/logs.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/activation/logs.ts)_
+_See code: [src/commands/activation/logs.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/activation/logs.ts)_
 
 ## `nim activation result [ACTIVATIONID]`
 
@@ -134,4 +134,4 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/activation/result.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/activation/result.ts)_
+_See code: [src/commands/activation/result.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/activation/result.ts)_

--- a/docs/nim-cmds/auth.md
+++ b/docs/nim-cmds/auth.md
@@ -36,7 +36,7 @@ OPTIONS
   --web          Show web domain (if available)
 ```
 
-_See code: [src/commands/auth/current.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/auth/current.ts)_
+_See code: [src/commands/auth/current.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/auth/current.ts)_
 
 ## `nim auth export [NAMESPACE]`
 
@@ -59,7 +59,7 @@ OPTIONS
   --non-expiring     Generate non-expiring token (for functional ids and integrations)
 ```
 
-_See code: [src/commands/auth/export.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/auth/export.ts)_
+_See code: [src/commands/auth/export.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/auth/export.ts)_
 
 ## `nim auth github`
 
@@ -84,7 +84,7 @@ OPTIONS
   --username=username  The GitHub username when adding an account manually
 ```
 
-_See code: [src/commands/auth/github.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/auth/github.ts)_
+_See code: [src/commands/auth/github.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/auth/github.ts)_
 
 ## `nim auth list`
 
@@ -97,11 +97,12 @@ USAGE
   $ nim auth list
 
 OPTIONS
-  -v, --verbose  Greater detail in error messages
-  --help         Show help
+  -v, --verbose      Greater detail in error messages
+  --apihost=apihost  Only list namespaces for the specified API host
+  --help             Show help
 ```
 
-_See code: [src/commands/auth/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/auth/list.ts)_
+_See code: [src/commands/auth/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/auth/list.ts)_
 
 ## `nim auth login [TOKEN]`
 
@@ -126,7 +127,7 @@ ALIASES
   $ nim login
 ```
 
-_See code: [src/commands/auth/login.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/auth/login.ts)_
+_See code: [src/commands/auth/login.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/auth/login.ts)_
 
 ## `nim auth logout [NAMESPACE]`
 
@@ -142,6 +143,7 @@ ARGUMENTS
   NAMESPACE  The namespace(s) you are dropping
 
 OPTIONS
+  -f, --force        Just do it, omitting confirmatory prompt
   -v, --verbose      Greater detail in error messages
   --all              log out of all namespaces (or, all on the given API host)
   --apihost=apihost  API host serving the namespace(s)
@@ -151,7 +153,7 @@ ALIASES
   $ nim logout
 ```
 
-_See code: [src/commands/auth/logout.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/auth/logout.ts)_
+_See code: [src/commands/auth/logout.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/auth/logout.ts)_
 
 ## `nim auth refresh [NAMESPACE]`
 
@@ -172,7 +174,7 @@ OPTIONS
   --help             Show help
 ```
 
-_See code: [src/commands/auth/refresh.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/auth/refresh.ts)_
+_See code: [src/commands/auth/refresh.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/auth/refresh.ts)_
 
 ## `nim auth switch NAMESPACE`
 
@@ -193,4 +195,4 @@ OPTIONS
   --help             Show help
 ```
 
-_See code: [src/commands/auth/switch.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/auth/switch.ts)_
+_See code: [src/commands/auth/switch.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/auth/switch.ts)_

--- a/docs/nim-cmds/doc.md
+++ b/docs/nim-cmds/doc.md
@@ -23,4 +23,4 @@ ALIASES
   $ nim docs
 ```
 
-_See code: [src/commands/doc.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/doc.ts)_
+_See code: [src/commands/doc.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/doc.ts)_

--- a/docs/nim-cmds/info.md
+++ b/docs/nim-cmds/info.md
@@ -24,4 +24,4 @@ OPTIONS
   --runtimes     List the supported runtimes
 ```
 
-_See code: [src/commands/info.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/info.ts)_
+_See code: [src/commands/info.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/info.ts)_

--- a/docs/nim-cmds/key-value.md
+++ b/docs/nim-cmds/key-value.md
@@ -36,7 +36,7 @@ ALIASES
   $ nim kv clean
 ```
 
-_See code: [src/commands/key-value/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/clean.ts)_
+_See code: [src/commands/key-value/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/clean.ts)_
 
 ## `nim key-value del KEY`
 
@@ -60,7 +60,7 @@ ALIASES
   $ nim key-value delete
 ```
 
-_See code: [src/commands/key-value/del.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/del.ts)_
+_See code: [src/commands/key-value/del.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/del.ts)_
 
 ## `nim key-value expire KEY TTL`
 
@@ -85,7 +85,7 @@ ALIASES
   $ nim kv expire
 ```
 
-_See code: [src/commands/key-value/expire.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/expire.ts)_
+_See code: [src/commands/key-value/expire.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/expire.ts)_
 
 ## `nim key-value get KEY`
 
@@ -109,7 +109,7 @@ ALIASES
   $ nim kv get
 ```
 
-_See code: [src/commands/key-value/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/get.ts)_
+_See code: [src/commands/key-value/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/get.ts)_
 
 ## `nim key-value getMany [KEYPREFIX] [STARTINDEX] [COUNT]`
 
@@ -136,7 +136,7 @@ ALIASES
   $ nim kv getmany
 ```
 
-_See code: [src/commands/key-value/getMany.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/getMany.ts)_
+_See code: [src/commands/key-value/getMany.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/getMany.ts)_
 
 ## `nim key-value list [PREFIX]`
 
@@ -162,7 +162,7 @@ ALIASES
   $ nim kv list
 ```
 
-_See code: [src/commands/key-value/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/list.ts)_
+_See code: [src/commands/key-value/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/list.ts)_
 
 ## `nim key-value llen KEY`
 
@@ -192,7 +192,7 @@ ALIASES
   $ nim kv llen
 ```
 
-_See code: [src/commands/key-value/llen.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/llen.ts)_
+_See code: [src/commands/key-value/llen.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/llen.ts)_
 
 ## `nim key-value lrange KEY START STOP`
 
@@ -224,7 +224,7 @@ ALIASES
   $ nim kv lrange
 ```
 
-_See code: [src/commands/key-value/lrange.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/lrange.ts)_
+_See code: [src/commands/key-value/lrange.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/lrange.ts)_
 
 ## `nim key-value rpush KEY VALUE`
 
@@ -255,7 +255,7 @@ ALIASES
   $ nim kv rpush
 ```
 
-_See code: [src/commands/key-value/rpush.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/rpush.ts)_
+_See code: [src/commands/key-value/rpush.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/rpush.ts)_
 
 ## `nim key-value set KEY VALUE`
 
@@ -281,7 +281,7 @@ ALIASES
   $ nim kv add
 ```
 
-_See code: [src/commands/key-value/set.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/set.ts)_
+_See code: [src/commands/key-value/set.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/set.ts)_
 
 ## `nim key-value setMany [KEYPREFIX] [VALUEPREFIX] [STARTINDEX] [COUNT]`
 
@@ -309,7 +309,7 @@ ALIASES
   $ nim kv setmany
 ```
 
-_See code: [src/commands/key-value/setMany.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/setMany.ts)_
+_See code: [src/commands/key-value/setMany.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/setMany.ts)_
 
 ## `nim key-value ttl KEY`
 
@@ -333,4 +333,4 @@ ALIASES
   $ nim kv ttl
 ```
 
-_See code: [src/commands/key-value/ttl.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/key-value/ttl.ts)_
+_See code: [src/commands/key-value/ttl.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/key-value/ttl.ts)_

--- a/docs/nim-cmds/namespace.md
+++ b/docs/nim-cmds/namespace.md
@@ -29,7 +29,7 @@ OPTIONS
   --justwhisk        Remove only OpenWhisk entities, leaving other content
 ```
 
-_See code: [src/commands/namespace/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/namespace/clean.ts)_
+_See code: [src/commands/namespace/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/namespace/clean.ts)_
 
 ## `nim namespace free [NAMESPACE]`
 
@@ -51,7 +51,7 @@ OPTIONS
   --help             Show help
 ```
 
-_See code: [src/commands/namespace/free.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/namespace/free.ts)_
+_See code: [src/commands/namespace/free.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/namespace/free.ts)_
 
 ## `nim namespace get`
 
@@ -79,4 +79,4 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/namespace/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/namespace/get.ts)_
+_See code: [src/commands/namespace/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/namespace/get.ts)_

--- a/docs/nim-cmds/object.md
+++ b/docs/nim-cmds/object.md
@@ -29,7 +29,7 @@ OPTIONS
   --namespace=namespace  The namespace to clean (current namespace if omitted)
 ```
 
-_See code: [src/commands/object/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/object/clean.ts)_
+_See code: [src/commands/object/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/object/clean.ts)_
 
 ## `nim object create OBJECTPATH`
 
@@ -56,7 +56,7 @@ ALIASES
   $ nim object add
 ```
 
-_See code: [src/commands/object/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/object/create.ts)_
+_See code: [src/commands/object/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/object/create.ts)_
 
 ## `nim object delete OBJECTNAME`
 
@@ -78,7 +78,7 @@ OPTIONS
   --namespace=namespace  The namespace to delete the object from (current namespace if omitted)
 ```
 
-_See code: [src/commands/object/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/object/delete.ts)_
+_See code: [src/commands/object/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/object/delete.ts)_
 
 ## `nim object get OBJECTNAME DESTINATION`
 
@@ -105,7 +105,7 @@ OPTIONS
   --saveAs=saveAs        Saves object on file system with the given name
 ```
 
-_See code: [src/commands/object/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/object/get.ts)_
+_See code: [src/commands/object/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/object/get.ts)_
 
 ## `nim object list [PREFIX]`
 
@@ -129,7 +129,7 @@ OPTIONS
   --namespace=namespace  The namespace to list objects from (current namespace if omitted)
 ```
 
-_See code: [src/commands/object/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/object/list.ts)_
+_See code: [src/commands/object/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/object/list.ts)_
 
 ## `nim object update OBJECTPATH`
 
@@ -152,7 +152,7 @@ OPTIONS
   --namespace=namespace          The namespace in which to update the object (current namespace if omitted)
 ```
 
-_See code: [src/commands/object/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/object/update.ts)_
+_See code: [src/commands/object/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/object/update.ts)_
 
 ## `nim object url OBJECTNAME`
 
@@ -176,4 +176,4 @@ OPTIONS
   --namespace=namespace        The namespace to get the object URL from (current namespace if omitted)
 ```
 
-_See code: [src/commands/object/url.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/object/url.ts)_
+_See code: [src/commands/object/url.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/object/url.ts)_

--- a/docs/nim-cmds/package.md
+++ b/docs/nim-cmds/package.md
@@ -38,7 +38,7 @@ OPTIONS
   --version                              Show version
 ```
 
-_See code: [src/commands/package/bind.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/package/bind.ts)_
+_See code: [src/commands/package/bind.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/package/bind.ts)_
 
 ## `nim package create PACKAGENAME`
 
@@ -69,7 +69,7 @@ OPTIONS
   --version                              Show version
 ```
 
-_See code: [src/commands/package/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/package/create.ts)_
+_See code: [src/commands/package/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/package/create.ts)_
 
 ## `nim package delete PACKAGENAME`
 
@@ -82,13 +82,14 @@ USAGE
   $ nim package delete PACKAGENAME
 
 OPTIONS
+  -f, --force        Just do it, omitting confirmatory prompt
   -r, --recursive    Delete the contained actions
   -u, --auth=auth    Whisk auth
   --apihost=apihost  Whisk API host
   --json             output raw json
 ```
 
-_See code: [src/commands/package/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/package/delete.ts)_
+_See code: [src/commands/package/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/package/delete.ts)_
 
 ## `nim package get PACKAGENAME`
 
@@ -113,7 +114,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/package/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/package/get.ts)_
+_See code: [src/commands/package/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/package/get.ts)_
 
 ## `nim package list [NAMESPACE]`
 
@@ -144,7 +145,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/package/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/package/list.ts)_
+_See code: [src/commands/package/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/package/list.ts)_
 
 ## `nim package update PACKAGENAME`
 
@@ -175,4 +176,4 @@ OPTIONS
   --version                              Show version
 ```
 
-_See code: [src/commands/package/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/package/update.ts)_
+_See code: [src/commands/package/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/package/update.ts)_

--- a/docs/nim-cmds/plugins.md
+++ b/docs/nim-cmds/plugins.md
@@ -4,6 +4,7 @@
 manage optional API specification sources
 
 * [`nim plugins`](#nim-plugins-)
+* [`nim plugins inspect PLUGIN...`](#nim-plugins-inspect-plugin)
 * [`nim plugins install PLUGIN...`](#nim-plugins-install-plugin)
 * [`nim plugins link PLUGIN`](#nim-plugins-link-plugin)
 * [`nim plugins uninstall PLUGIN...`](#nim-plugins-uninstall-plugin)
@@ -26,7 +27,30 @@ EXAMPLE
   $ nim plugins
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.9.5/src/commands/plugins/index.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.10.0/src/commands/plugins/index.ts)_
+
+## `nim plugins inspect PLUGIN...`
+
+displays installation properties of a plugin
+
+```
+displays installation properties of a plugin
+
+USAGE
+  $ nim plugins inspect PLUGIN...
+
+ARGUMENTS
+  PLUGIN  [default: .] plugin to inspect
+
+OPTIONS
+  -h, --help     show CLI help
+  -v, --verbose
+
+EXAMPLE
+  $ nim plugins inspect myplugin
+```
+
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.10.0/src/commands/plugins/inspect.ts)_
 
 ## `nim plugins install PLUGIN...`
 
@@ -57,8 +81,8 @@ DESCRIPTION
 
   Installation of a user-installed plugin will override a core plugin.
 
-  e.g. If you have a core plugin that has a 'hello' command, installing a user-installed plugin with a 'hello' command will override the core plugin implementation. This is 
-  useful if a user needs to update core plugin functionality in the CLI without the need to patch and update the whole CLI.
+  e.g. If you have a core plugin that has a 'hello' command, installing a user-installed plugin with a 'hello' command will override the core plugin implementation. This is useful if a user needs to 
+  update core plugin functionality in the CLI without the need to patch and update the whole CLI.
 
 ALIASES
   $ nim plugins add
@@ -69,7 +93,7 @@ EXAMPLES
   $ nim plugins install someuser/someplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.9.5/src/commands/plugins/install.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.10.0/src/commands/plugins/install.ts)_
 
 ## `nim plugins link PLUGIN`
 
@@ -95,14 +119,14 @@ OPTIONS
 DESCRIPTION
   Installation of a linked plugin will override a user-installed or core plugin.
 
-  e.g. If you have a user-installed or core plugin that has a 'hello' command, installing a linked plugin with a 'hello' command will override the user-installed or core plugin 
-  implementation. This is useful for development work.
+  e.g. If you have a user-installed or core plugin that has a 'hello' command, installing a linked plugin with a 'hello' command will override the user-installed or core plugin implementation. This is 
+  useful for development work.
 
 EXAMPLE
   $ nim plugins link myplugin
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.9.5/src/commands/plugins/link.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.10.0/src/commands/plugins/link.ts)_
 
 ## `nim plugins uninstall PLUGIN...`
 
@@ -126,7 +150,7 @@ ALIASES
   $ nim plugins remove
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.9.5/src/commands/plugins/uninstall.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.10.0/src/commands/plugins/uninstall.ts)_
 
 ## `nim plugins update`
 
@@ -143,4 +167,4 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.9.5/src/commands/plugins/update.ts)_
+_See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v1.10.0/src/commands/plugins/update.ts)_

--- a/docs/nim-cmds/project.md
+++ b/docs/nim-cmds/project.md
@@ -30,7 +30,7 @@ OPTIONS
   --help                                                                         Show help
 ```
 
-_See code: [src/commands/project/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/project/create.ts)_
+_See code: [src/commands/project/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/project/create.ts)_
 
 ## `nim project deploy [PROJECTS]`
 
@@ -65,7 +65,7 @@ OPTIONS
   --yarn                 Use yarn instead of npm for node builds
 ```
 
-_See code: [src/commands/project/deploy.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/project/deploy.ts)_
+_See code: [src/commands/project/deploy.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/project/deploy.ts)_
 
 ## `nim project serve-web LOCATION`
 
@@ -87,7 +87,7 @@ OPTIONS
   --namespace=namespace  The namespace to proxy (current namespace if omitted)
 ```
 
-_See code: [src/commands/project/serve-web.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/project/serve-web.ts)_
+_See code: [src/commands/project/serve-web.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/project/serve-web.ts)_
 
 ## `nim project watch [PROJECTS]`
 
@@ -119,4 +119,4 @@ OPTIONS
   --yarn                 Use yarn instead of npm for node builds
 ```
 
-_See code: [src/commands/project/watch.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/project/watch.ts)_
+_See code: [src/commands/project/watch.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/project/watch.ts)_

--- a/docs/nim-cmds/route.md
+++ b/docs/nim-cmds/route.md
@@ -40,7 +40,7 @@ OPTIONS
   --version                                         Show version
 ```
 
-_See code: [src/commands/route/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/route/create.ts)_
+_See code: [src/commands/route/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/route/create.ts)_
 
 ## `nim route delete BASEPATHORAPINAME [RELPATH] [APIVERB]`
 
@@ -70,7 +70,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/route/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/route/delete.ts)_
+_See code: [src/commands/route/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/route/delete.ts)_
 
 ## `nim route get BASEPATHORAPINAME`
 
@@ -98,7 +98,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/route/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/route/get.ts)_
+_See code: [src/commands/route/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/route/get.ts)_
 
 ## `nim route list [BASEPATH] [RELPATH] [APIVERB]`
 
@@ -131,4 +131,4 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/route/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/route/list.ts)_
+_See code: [src/commands/route/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/route/list.ts)_

--- a/docs/nim-cmds/rule.md
+++ b/docs/nim-cmds/rule.md
@@ -41,7 +41,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/rule/create.ts)_
+_See code: [src/commands/rule/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/rule/create.ts)_
 
 ## `nim rule delete NAME`
 
@@ -57,6 +57,7 @@ ARGUMENTS
   NAME  Name of the rule
 
 OPTIONS
+  -f, --force              Just do it, omitting confirmatory prompt
   -i, --insecure           bypass certificate check
   -u, --auth=auth          whisk auth
   -v, --verbose            Verbose output
@@ -70,7 +71,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/rule/delete.ts)_
+_See code: [src/commands/rule/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/rule/delete.ts)_
 
 ## `nim rule disable NAME`
 
@@ -98,7 +99,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/disable.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/rule/disable.ts)_
+_See code: [src/commands/rule/disable.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/rule/disable.ts)_
 
 ## `nim rule enable NAME`
 
@@ -126,7 +127,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/enable.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/rule/enable.ts)_
+_See code: [src/commands/rule/enable.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/rule/enable.ts)_
 
 ## `nim rule get NAME`
 
@@ -154,7 +155,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/rule/get.ts)_
+_See code: [src/commands/rule/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/rule/get.ts)_
 
 ## `nim rule list`
 
@@ -185,7 +186,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/rule/list.ts)_
+_See code: [src/commands/rule/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/rule/list.ts)_
 
 ## `nim rule status NAME`
 
@@ -213,7 +214,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/status.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/rule/status.ts)_
+_See code: [src/commands/rule/status.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/rule/status.ts)_
 
 ## `nim rule update NAME TRIGGER ACTION`
 
@@ -244,4 +245,4 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/rule/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/rule/update.ts)_
+_See code: [src/commands/rule/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/rule/update.ts)_

--- a/docs/nim-cmds/trigger.md
+++ b/docs/nim-cmds/trigger.md
@@ -41,7 +41,7 @@ OPTIONS
   --version                              Show version
 ```
 
-_See code: [src/commands/trigger/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/trigger/create.ts)_
+_See code: [src/commands/trigger/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/trigger/create.ts)_
 
 ## `nim trigger delete TRIGGERPATH`
 
@@ -57,6 +57,7 @@ ARGUMENTS
   TRIGGERPATH  The name of the trigger, in the format /NAMESPACE/NAME
 
 OPTIONS
+  -f, --force              Just do it, omitting confirmatory prompt
   -i, --insecure           bypass certificate check
   -u, --auth=auth          whisk auth
   -v, --verbose            Verbose output
@@ -69,7 +70,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/trigger/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/trigger/delete.ts)_
+_See code: [src/commands/trigger/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/trigger/delete.ts)_
 
 ## `nim trigger fire TRIGGERNAME`
 
@@ -99,7 +100,7 @@ OPTIONS
   --version                    Show version
 ```
 
-_See code: [src/commands/trigger/fire.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/trigger/fire.ts)_
+_See code: [src/commands/trigger/fire.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/trigger/fire.ts)_
 
 ## `nim trigger get TRIGGERPATH`
 
@@ -127,7 +128,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/trigger/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/trigger/get.ts)_
+_See code: [src/commands/trigger/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/trigger/get.ts)_
 
 ## `nim trigger list`
 
@@ -158,7 +159,7 @@ OPTIONS
   --version                Show version
 ```
 
-_See code: [src/commands/trigger/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/trigger/list.ts)_
+_See code: [src/commands/trigger/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/trigger/list.ts)_
 
 ## `nim trigger update TRIGGERNAME`
 
@@ -190,4 +191,4 @@ OPTIONS
   --version                              Show version
 ```
 
-_See code: [src/commands/trigger/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/trigger/update.ts)_
+_See code: [src/commands/trigger/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/trigger/update.ts)_

--- a/docs/nim-cmds/web.md
+++ b/docs/nim-cmds/web.md
@@ -28,7 +28,7 @@ OPTIONS
   --namespace=namespace  The namespace to clean (current namespace if omitted)
 ```
 
-_See code: [src/commands/web/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/web/clean.ts)_
+_See code: [src/commands/web/clean.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/web/clean.ts)_
 
 ## `nim web create WEBCONTENTPATH`
 
@@ -55,7 +55,7 @@ ALIASES
   $ nim web add
 ```
 
-_See code: [src/commands/web/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/web/create.ts)_
+_See code: [src/commands/web/create.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/web/create.ts)_
 
 ## `nim web delete WEBCONTENTNAME`
 
@@ -77,7 +77,7 @@ OPTIONS
   --namespace=namespace  The namespace in which to delete content (current namespace if omitted)
 ```
 
-_See code: [src/commands/web/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/web/delete.ts)_
+_See code: [src/commands/web/delete.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/web/delete.ts)_
 
 ## `nim web get WEBCONTENTNAME DESTINATION`
 
@@ -105,7 +105,7 @@ OPTIONS
   --saveAs=saveAs        Saves content on file system with the given name
 ```
 
-_See code: [src/commands/web/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/web/get.ts)_
+_See code: [src/commands/web/get.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/web/get.ts)_
 
 ## `nim web list [PREFIX]`
 
@@ -129,7 +129,7 @@ OPTIONS
   --namespace=namespace  The namespace to list web content from (current namespace if omitted)
 ```
 
-_See code: [src/commands/web/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/web/list.ts)_
+_See code: [src/commands/web/list.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/web/list.ts)_
 
 ## `nim web update WEBCONTENTPATH`
 
@@ -153,4 +153,4 @@ OPTIONS
   --namespace=namespace          The namespace in which to update content (current namespace if omitted)
 ```
 
-_See code: [src/commands/web/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/web/update.ts)_
+_See code: [src/commands/web/update.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/web/update.ts)_

--- a/docs/nim-cmds/workbench.md
+++ b/docs/nim-cmds/workbench.md
@@ -25,7 +25,7 @@ ALIASES
   $ nim wb login
 ```
 
-_See code: [src/commands/workbench/login.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/workbench/login.ts)_
+_See code: [src/commands/workbench/login.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/workbench/login.ts)_
 
 ## `nim workbench run [COMMAND]`
 
@@ -49,4 +49,4 @@ ALIASES
   $ nim wb run
 ```
 
-_See code: [src/commands/workbench/run.ts](https://github.com/nimbella/nimbella-cli/blob/v1.13.0/src/commands/workbench/run.ts)_
+_See code: [src/commands/workbench/run.ts](https://github.com/nimbella/nimbella-cli/blob/v1.14.0/src/commands/workbench/run.ts)_


### PR DESCRIPTION
This updates the auto-generated `nim` command summary docs to version 1.14.0.   I had this as a draft for a while as I worked out why some things weren't working.  This had to do with tagging in the public nimbella-cli repo and was not due to an oclif change as I had feared.   It appears all of the links are working now.